### PR TITLE
Add helper script for displaying tile lists as geojson

### DIFF
--- a/lib/tiles-to-geo.js
+++ b/lib/tiles-to-geo.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+var split = require('split')
+var through = require('through2')
+var tilebelt = require('tilebelt')
+var gs = require('geojson-stream')
+var bb = require('turf-bbox-polygon')
+
+module.exports = readSample
+
+// Read a list of tiles from stdin, in the form:
+// file.mbtiles z x y [optional additional data]
+// Return an object stream of `[z, x, y]` tile objects that also have properties:
+// `.source` for the filename and `.data` for whatever other (space delimited)
+// data was on the line.
+function readSample () {
+  return process.stdin
+  .pipe(split())
+  .pipe(through.obj(function (line, enc, next) {
+    if (!line.trim() || /^\s*#/.test(line)) { return next() }
+    var parts = line.split(' ')
+    var tile = parts.slice(1, 4).map(Number)
+
+    var geo = bb(tilebelt.tileToBBOX([tile[1], tile[2], tile[0]]))
+
+    if (tile.length === 3) {
+      this.push(geo)
+    }
+
+    next()
+  }))
+  .pipe(gs.stringify())
+  .pipe(process.stdout)
+}
+
+if (require.main === module) {
+  readSample()
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "tilebelt": "^1.0.1",
     "tilejson": "^1.0.1",
     "tilelive": "^5.12.2",
-    "tilelive-vector": "^3.9.2"
+    "tilelive-vector": "^3.9.2",
+    "turf-bbox-polygon": "^3.0.12"
   },
   "devDependencies": {
     "eslint": "^2.7.0",


### PR DESCRIPTION
Used like:

```bash
cat data/sample-filtered.txt | node lib/tiles-to-geo.js
```