### PR TITLE
Label preformance improvments

### DIFF
--- a/lib/write-tile.js
+++ b/lib/write-tile.js
@@ -3,9 +3,6 @@ var path = require('path')
 const blank = new Buffer('89504e470d0a1a0a0000000d494844520000010000000100010300000066bc3a2500000003504c5445000000a77a3dda0000001f494441546881edc1010d000000c2a0f74f6d0e37a00000000000000000be0d210000019a60e1d50000000049454e44ae426082', 'hex');
 
 module.exports = function writeTile (output, source, tile, cb, removeBlank) {
-  if(!removeBlank){
-    removeBlank=false
-  }
   var filename = path.join(output, tile.join('-') + '.png')
   fs.exists(filename, function (exists) {
     if (exists) { return cb() }

--- a/lib/write-tile.js
+++ b/lib/write-tile.js
@@ -16,11 +16,12 @@ module.exports = function writeTile (output, source, tile, cb, removeBlank) {
         console.error('Error processing tile ' + tile, err.message || err)
         if (cb) { return cb() }
       }
+      //skip images which are blank if the label ratio > 0
       if(!removeBlank || !blank.equals(image)){
         console.log('Writing ' + filename)
         fs.writeFileSync(filename, image)
       }else{
-        console.log(filename + " blank, not Writing")
+        console.log(filename + " blank, not Writing") 
       }
       if (cb) { cb() }
     })

--- a/lib/write-tile.js
+++ b/lib/write-tile.js
@@ -1,7 +1,11 @@
 var fs = require('fs')
 var path = require('path')
+const blank = new Buffer('89504e470d0a1a0a0000000d494844520000010000000100010300000066bc3a2500000003504c5445000000a77a3dda0000001f494441546881edc1010d000000c2a0f74f6d0e37a00000000000000000be0d210000019a60e1d50000000049454e44ae426082', 'hex');
 
-module.exports = function writeTile (output, source, tile, cb) {
+module.exports = function writeTile (output, source, tile, cb, removeBlank) {
+  if(!removeBlank){
+    removeBlank=false
+  }
   var filename = path.join(output, tile.join('-') + '.png')
   fs.exists(filename, function (exists) {
     if (exists) { return cb() }
@@ -12,9 +16,12 @@ module.exports = function writeTile (output, source, tile, cb) {
         console.error('Error processing tile ' + tile, err.message || err)
         if (cb) { return cb() }
       }
-
-      console.log('Writing ' + filename)
-      fs.writeFileSync(filename, image)
+      if(!removeBlank || !blank.equals(image)){
+        console.log('Writing ' + filename)
+        fs.writeFileSync(filename, image)
+      }else{
+        console.log(filename + " blank, not Writing")
+      }
       if (cb) { cb() }
     })
   })

--- a/rasterize-labels
+++ b/rasterize-labels
@@ -14,6 +14,7 @@ var writeTile = require('./lib/write-tile')
 var input = argv._[0] // usually an osm qa tiles mbtiles file
 var layers = require(path.resolve(argv._[1])) // json file defining classes
 var output = argv._[2] // output dir
+var labelRatio = argv._[3]
 
 init(input, style(layers), function (err, vector) {
   if (err) { throw err }
@@ -23,7 +24,11 @@ init(input, style(layers), function (err, vector) {
   readSample(argv)
   .on('data', function (tile) {
     q.defer(function (done) {
-      writeTile(output, vector, tile, done)
+      if(labelRatio > 0){
+        writeTile(output, vector, tile, done, true)
+      }else{
+        writeTile(output, vector, tile, done, false)
+      }
     })
   })
   .on('end', function () {

--- a/rasterize-labels
+++ b/rasterize-labels
@@ -24,6 +24,8 @@ init(input, style(layers), function (err, vector) {
   readSample(argv)
   .on('data', function (tile) {
     q.defer(function (done) {
+      //skip images which are blank if the label ratio > 0
+      //helps with case where images with a label_ratio>0 are sparse
       if(labelRatio > 0){
         writeTile(output, vector, tile, done, true)
       }else{


### PR DESCRIPTION
In the case where images with a LABEL_RATIO>0 are sparse (something I've encountered a lot with power infrastructure data), the program spends a lot of time writing blank tiles that are later thrown out when making sample_filtered. Additionally, in this case, checking a label for equality against the blank image file is much faster than creating an entry in label-counts.txt.