### PR TITLE
Aerial imagery should be jpg, labels png

### DIFF
--- a/download-images
+++ b/download-images
@@ -18,7 +18,7 @@ tilelive.load(input, function (err, source) {
   readSample(argv)
   .on('data', function (tile) {
     q.defer(function (done) {
-      writeTile(output, source, tile, done)
+      writeTile(output, source, tile, done, false, '.jpg')
     })
   })
   .on('end', function () {

--- a/lib/write-tile.js
+++ b/lib/write-tile.js
@@ -2,8 +2,8 @@ var fs = require('fs')
 var path = require('path')
 const blank = new Buffer('89504e470d0a1a0a0000000d494844520000010000000100010300000066bc3a2500000003504c5445000000a77a3dda0000001f494441546881edc1010d000000c2a0f74f6d0e37a00000000000000000be0d210000019a60e1d50000000049454e44ae426082', 'hex');
 
-module.exports = function writeTile (output, source, tile, cb, removeBlank) {
-  var filename = path.join(output, tile.join('-') + '.png')
+module.exports = function writeTile (output, source, tile, cb, removeBlank, extension) {
+  var filename = path.join(output, tile.join('-') + extension)
   fs.exists(filename, function (exists) {
     if (exists) { return cb() }
     console.log('Reading ' + tile)

--- a/list-image-pairs
+++ b/list-image-pairs
@@ -18,20 +18,20 @@ var fullLabelsPath = argv.labels ? path.resolve(basedir, argv.labels) : false
 
 readSample(argv)
 .pipe(through.obj(function (tile, _, next) {
-  var filename = tile.join('-') + '.png'
+  var filename = tile.join('-')
 
-  if (fullImagesPath && !fs.existsSync(path.join(fullImagesPath, filename))) {
+  if (fullImagesPath && !fs.existsSync(path.join(fullImagesPath, filename + '.jpg'))) {
     console.error('Cannot find image ' + filename)
     return next()
   }
 
-  if (fullLabelsPath && !fs.existsSync(path.join(fullLabelsPath, filename))) {
+  if (fullLabelsPath && !fs.existsSync(path.join(fullLabelsPath, filename + '.png'))) {
     console.error('Cannot find label ' + filename)
     return next()
   }
 
-  var image = path.join('/data', argv.images, filename)
-  var label = path.join('/data', argv.labels, filename)
+  var image = path.join('/data', argv.images, filename + '.jpg')
+  var label = path.join('/data', argv.labels, filename + '.png')
   this.push(image + ' ' + label + '\n')
   next()
 }))

--- a/rasterize-labels
+++ b/rasterize-labels
@@ -27,9 +27,9 @@ init(input, style(layers), function (err, vector) {
       //skip images which are blank if the label ratio > 0
       //helps with case where images with a label_ratio>0 are sparse
       if(labelRatio > 0){
-        writeTile(output, vector, tile, done, true)
+        writeTile(output, vector, tile, done, true, '.png')
       }else{
-        writeTile(output, vector, tile, done, false)
+        writeTile(output, vector, tile, done, false, '.png')
       }
     })
   })


### PR DESCRIPTION
Hi, thanks for this great tool. I've just added a quick little change to save the imagery with a `jpg` extension instead of `png` (as they are jpegs, not pngs) so my image viewing programs don't get confused when I try to display them.