### PR TITLE
Made it easier to run local docker container with docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data
 node_modules
+docker.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 data
 node_modules
-docker.env
+docker.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ WORKDIR /workdir
 ADD package.json /workdir/package.json
 RUN npm install
 
+# downgrade to non-privileged user
+RUN groupadd -g 1000 -r data && useradd --no-log-init -r -u 1000 -g data data
+USER data
+
 ADD . /workdir
 
 ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ data/image-pairs.txt: data/sample-filtered.txt data/labels/grayscale data/images
 
 # Make train & val lists, with 80% of data -> train, 20% -> val
 data/train.txt: data/image-pairs.txt
-	shuf data/image-pairs.txt > temp.txt
-	split -l $$(($$(cat data/image-pairs.txt | wc -l) * 4 / 5)) temp.txt
-	rm temp.txt
-	mv xaa $@
-	mv xab data/val.txt
+	shuf data/image-pairs.txt > data/temp.txt
+	split -l $$(($$(cat data/image-pairs.txt | wc -l) * 4 / 5)) data/temp.txt data/x
+	rm data/temp.txt
+	mv data/xaa $@
+	mv data/xab data/val.txt
 
 .PHONY: all
 all: data/train.txt data/val.txt

--- a/README.md
+++ b/README.md
@@ -16,13 +16,23 @@ imagery.
 
 ## Quick Start
 
+### Pre-built docker image
+
 The easiest way to use this is via the
 [`developmentseed/skynet-data` docker image](https://hub.docker.com/r/developmentseed/skynet-data):
 
-```sh
-docker run -d -v /path/to/output/dir:/workdir/data developmentseed/skynet-data download-osm-tiles
+First, create a `docker.env` file with the contents including your MapboxAccessToken:
 
-docker run -d -v /path/to/output/dir:/workdir/data -e MapboxAccessToken=YOUR_TOKEN developmentseed/skynet-data
+```
+MapboxAccessToken=YOUR_TOKEN
+```
+
+Then run:
+
+```sh
+docker run -d -v /path/to/output/dir:/workdir/data --env-file docker.env developmentseed/skynet-data download-osm-tiles
+
+docker run -d -v /path/to/output/dir:/workdir/data --env-file docker.env developmentseed/skynet-data
 ```
 
 The first line downloads the OSM QA tiles to
@@ -31,9 +41,33 @@ file on your machine, you can skip this.
 
 The second builds a training set using the default options (Roads
 features from OSM QA tiles, images from Mapbox Satellite).  To change
-the data sources, training set size and other options, send the
-relevant environment variables (see below) into `docker run` with `-e
-VAR=value`.
+the data sources, training set size and other options, add the
+relevant environment variables to the `docker.env` file , one per
+line.
+
+### Local docker image
+
+You can also create the docker images yourself using
+docker-compose. Similarly to the quick-start above, make sure your
+`docker.env` file has your MapboxAccessToken and any other environment
+variables you want to set. Then run:
+
+```
+docker-compose build
+```
+
+to build your local docker image, and 
+
+```
+docker-compose run data download-osm-tiles
+docker-compose run data 
+```
+
+to download the OSM QA tiles, and run the data collection as specified
+in `docker.env`. By default the collected data will be saved into the
+`data` directory, but you can overide it by using `-v
+/path/to/output/dir:/workdir/data` after `docker-compose run data`
+similar to the pre-built instructions above.
 
 ## Variables
 
@@ -60,7 +94,8 @@ LABEL_RATIO ?= 0
 ZOOM_LEVEL ?= 17
 ```
 
-Make a full training set according to these params with `make all`.
+You can override any of these parameters in your `docker.env` and make
+a full training set using the instructions above.
 
 ## Details
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,17 @@ images where each color represents some category derived from OSM features.
 Being map tiles, it's then pretty easy to match these up with the desired input
 imagery.
 
- - OSM QA tile data [copyright OpenStreetMap contributors](http://www.openstreetmap.org/copyright) and licensed under [ODbL](http://opendatacommons.org/licenses/odbl/)
- - Mapbox Satellite data can be [traced for noncommercial purposes](https://www.mapbox.com/tos/#[YmtMIywt]).
+ - OSM QA tile data
+   [copyright OpenStreetMap contributors](http://www.openstreetmap.org/copyright)
+   and licensed under
+   [ODbL](http://opendatacommons.org/licenses/odbl/)
+ - Mapbox Satellite data can be
+   [traced for noncommercial purposes](https://www.mapbox.com/tos/#[YmtMIywt]).
 
 ## Quick Start
 
-The easiest way to use this is via the [`developmentseed/skynet-data` docker image](https://hub.docker.com/r/developmentseed/skynet-data):
+The easiest way to use this is via the
+[`developmentseed/skynet-data` docker image](https://hub.docker.com/r/developmentseed/skynet-data):
 
 ```sh
 docker run -d -v /path/to/output/dir:/workdir/data developmentseed/skynet-data download-osm-tiles
@@ -20,14 +25,20 @@ docker run -d -v /path/to/output/dir:/workdir/data developmentseed/skynet-data d
 docker run -d -v /path/to/output/dir:/workdir/data -e MapboxAccessToken=YOUR_TOKEN developmentseed/skynet-data
 ```
 
-The first line downloads the OSM QA tiles to `/path/to/output/dir/osm/planet.mbtiles`.  If you've already got that file on your machine, you can skip this.
+The first line downloads the OSM QA tiles to
+`/path/to/output/dir/osm/planet.mbtiles`.  If you've already got that
+file on your machine, you can skip this.
 
-The second builds a training set using the default options (Roads features from OSM QA tiles, images from Mapbox Satellite).  To change the data sources, training set size and other options, send the relevant environment variables (see below) into `docker run` with `-e VAR=value`.
+The second builds a training set using the default options (Roads
+features from OSM QA tiles, images from Mapbox Satellite).  To change
+the data sources, training set size and other options, send the
+relevant environment variables (see below) into `docker run` with `-e
+VAR=value`.
 
 ## Variables
 
-The `make` commands below work off the following variables (with defaults as
-listed):
+The `make` commands below work off the following variables (with
+defaults as listed):
 
 ```
 # location of image files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   data:
     build: .
     volumes:
-    - ./data:/workdir/data
+    - ./:/workdir
+    - /workdir/node_modules
     env_file:
     - docker.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  data:
+    build: .
+    volumes:
+    - ./data:/workdir/data
+    env_file:
+    - docker.env


### PR DESCRIPTION
I was finding some inefficiencies in having to build and run my own local docker instead of using the prebuilt ones, so I set up a single container docker-compose to help out. This PR has the following main changes:

1. docker container now runs as non-priviledged user instead of root (no more root-owned files in your data directory)
2. environment files can be saved in a (gitignored) docker.env file to avoid having to pass many configuration parameters on the command line
3. local docker builds are as easy as `docker-compose build`, `docker-compose run data download-osm-tiles`, `docker-compose run data`.
4. because docker-compose mounts the code into the container as a volume, you can make changes without having to rebuild (unless you need to refresh the node_modules - then you need to rebuild).

I have also updated the README to reflect these changes.

I would appreciate any comments you have and are happy to help improve this PR in any way to help get it in.